### PR TITLE
Add dtmf options from RTCSession to Call

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -421,9 +421,9 @@ class Call {
     _session.unmute(audio, video);
   }
 
-  void sendDTMF(String tones) {
+  void sendDTMF(String tones, [Map<String, dynamic> options]) {
     assert(_session != null, 'ERROR(sendDTMF): rtc session is invalid!');
-    _session.sendDTMF(tones);
+    _session.sendDTMF(tones, options);
   }
 
   String get remote_display_name {


### PR DESCRIPTION
Related to my feature request #153, I have added the DTMF options to the method in Call. 
It should be an optional parameter, however, I couldn't use the flutter tests to verify that all functionality still works as expected, as I am missing the required SIP server locally.