### PR TITLE
Let the user override the call options by extending SIPUAHelper

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -70,7 +70,7 @@ class SIPUAHelper extends EventManager {
 
   Future<bool> call(String target, [bool voiceonly = false]) async {
     if (_ua != null && _ua.isConnected()) {
-      _ua.call(target, _options(voiceonly));
+      _ua.call(target, buildCallOptions(voiceonly));
       return true;
     } else {
       logger.error(
@@ -157,7 +157,7 @@ class SIPUAHelper extends EventManager {
         if (session.direction == 'incoming') {
           // Set event handlers.
           session
-              .addAllEventHandlers(_options()['eventHandlers'] as EventManager);
+              .addAllEventHandlers(buildCallOptions()['eventHandlers'] as EventManager);
         }
         _calls[event.id] =
             Call(event.id, session, CallStateEnum.CALL_INITIATION);
@@ -181,6 +181,9 @@ class SIPUAHelper extends EventManager {
     }
   }
 
+  /// Build the call options.
+  /// You may override this method in a custom SIPUAHelper class in order to
+  /// modify the options to your needs.
   Map<String, Object> buildCallOptions([bool voiceonly = false]) =>
       _options(voiceonly);
 
@@ -260,7 +263,7 @@ class SIPUAHelper extends EventManager {
       //Always accept.
       refer.accept((RTCSession session) {
         logger.debug('session initialized.');
-      }, _options(true));
+      }, buildCallOptions(true));
     });
 
     Map<String, Object> _defaultOptions = <String, dynamic>{


### PR DESCRIPTION
The method `buildCallOptions` was already there but not used and instead `_options` was used directly so that I cannot override the default options by extending the SIPUAHelper class in a custom class and use the custom class instead.

This will affect #169 as the `sdpSemantics` property cannot be set currently. After this merge we can modify the `pcConfig` key-value pair in the options map returned from `buildCallOptions`.