### PR TITLE
Configuring via_transport

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -548,6 +548,11 @@ class WebSocketSettings {
   /// Don‘t check the server certificate
   /// for self-signed certificate.
   bool allowBadCertificate = false;
+
+  /// Custom transport scheme string to use.
+  /// Otherwise the used protocol will be used (for example WS for ws://
+  /// or WSS for wss://, based on the given web socket URL).
+  String transport_scheme;
 }
 
 enum DtmfMode {

--- a/lib/src/transports/websocket_interface.dart
+++ b/lib/src/transports/websocket_interface.dart
@@ -18,8 +18,8 @@ class WebSocketInterface implements Socket {
       logger.error('invalid WebSocket URI scheme: ${parsed_url.scheme}');
       throw AssertionError('Invalid argument: $url');
     } else {
-      String transport_scheme = webSocketSettings != null
-          ? webSocketSettings.transport_scheme?.toLowerCase()
+      String transport_scheme = webSocketSettings != null && webSocketSettings.transport_scheme != null
+          ? webSocketSettings.transport_scheme.toLowerCase()
           : parsed_url.scheme;
 
       String port = parsed_url.port != null ? ':${parsed_url.port}' : '';

--- a/lib/src/transports/websocket_interface.dart
+++ b/lib/src/transports/websocket_interface.dart
@@ -19,7 +19,7 @@ class WebSocketInterface implements Socket {
       throw AssertionError('Invalid argument: $url');
     } else {
       String transport_scheme = webSocketSettings != null
-          ? webSocketSettings.transport_scheme.toLowerCase()
+          ? webSocketSettings.transport_scheme?.toLowerCase()
           : parsed_url.scheme;
 
       String port = parsed_url.port != null ? ':${parsed_url.port}' : '';

--- a/lib/src/transports/websocket_interface.dart
+++ b/lib/src/transports/websocket_interface.dart
@@ -18,10 +18,14 @@ class WebSocketInterface implements Socket {
       logger.error('invalid WebSocket URI scheme: ${parsed_url.scheme}');
       throw AssertionError('Invalid argument: $url');
     } else {
+      String transport_scheme = webSocketSettings != null
+          ? webSocketSettings.transport_scheme.toLowerCase()
+          : parsed_url.scheme;
+
       String port = parsed_url.port != null ? ':${parsed_url.port}' : '';
-      _sip_uri = 'sip:${parsed_url.host}$port;transport=${parsed_url.scheme}';
+      _sip_uri = 'sip:${parsed_url.host}$port;transport=$transport_scheme';
       logger.debug('SIP URI: $_sip_uri');
-      _via_transport = parsed_url.scheme.toUpperCase();
+      _via_transport = transport_scheme.toUpperCase();
     }
     _webSocketSettings = webSocketSettings ?? WebSocketSettings();
   }


### PR DESCRIPTION
I know this is kind of a crazy change as it lets the user configure the `via_transport` String used.
But we have the problem that we have a server that is using an URL prefixed with `wss://` but expecting `VIA SIP/2.0/WS` instead of `VIA SIP/2.0/WSS`.
So I figured it would not hurt if the user would be able to customize it.