### PR TITLE
Fixed mute audio for unified-plan

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -2866,23 +2866,19 @@ class RTCSession extends EventManager {
   }
 
   void _toggleMuteAudio(bool mute) {
-    List<MediaStream> streams = _connection.getLocalStreams();
-    streams.forEach((MediaStream stream) {
-      if (stream.getAudioTracks().isNotEmpty) {
-        MediaStreamTrack track = stream.getAudioTracks()[0];
+    if (_localMediaStream != null) {
+      for (MediaStreamTrack track in _localMediaStream.getAudioTracks()) {
         track.enabled = !mute;
       }
-    });
+    }
   }
 
   void _toggleMuteVideo(bool mute) {
-    List<MediaStream> streams = _connection.getLocalStreams();
-    streams.forEach((MediaStream stream) {
-      if (stream.getVideoTracks().isNotEmpty) {
-        MediaStreamTrack track = stream.getVideoTracks()[0];
+    if (_localMediaStream != null) {
+      for (MediaStreamTrack track in _localMediaStream.getVideoTracks()) {
         track.enabled = !mute;
       }
-    });
+    }
   }
 
   void _newRTCSession(String originator, dynamic request) {


### PR DESCRIPTION
Hi there me again!

We found out that now with `unified-plan` mute wasn't working anymore as there were no streams added to `_connection.getLocalStreams()` as we only call `addTrack`.

As we only have one stream called `_localMediaStream` in the `RTCSession` we thought it might make sense to just use that one for muting. Is that ok or do you have doubts?