### PR TITLE
bump dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   crypto: ^3.0.0
-  flutter_webrtc: ^0.5.8
+  flutter_webrtc: ^0.6.5
   intl: any
-  logger: ^0.9.0
-  parser_error: ^0.1.1
+  logger: ^1.0.0
+  parser_error: ^0.2.0
   path: ^1.6.4
   random_string: ^2.0.0
-  recase: ^3.0.0
+  recase: ^4.0.0
   sdp_transform: ^0.3.0
   uuid: ^3.0.2
   


### PR DESCRIPTION
need to get around this error
`sip_ua depends on crypto ^2.1.2 and universal_io >=2.0.0 depends on crypto ^3.0.0`

tested and working with camera too.