### PR TITLE
Don't run ready function if session has been terminated

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -1652,6 +1652,7 @@ class RTCSession extends EventManager {
     // Add 'pc.onicencandidate' event handler to resolve on last candidate.
     bool finished = false;
     Future<Null> Function() ready = () async {
+      if (_status != C.STATUS_TERMINATED) {
       _connection.onIceCandidate = null;
       _connection.onIceGatheringState = null;
       _connection.onIceConnectionState = null;
@@ -1662,6 +1663,8 @@ class RTCSession extends EventManager {
       logger.debug('emit "sdp"');
       emit(EventSdp(originator: 'local', type: type, sdp: desc.sdp));
       completer.complete(desc);
+      }
+      
     };
 
     _connection.onIceGatheringState = (RTCIceGatheringState state) {


### PR DESCRIPTION
**Problem**:
If session has been terminated during setTimeout for `ready` function that `function` will throw an exception `NoSuchMethodError: The setter 'onIceCandidate=' was called on null.`. That happens because by that time `_connection` is `null` and we try to access `onIceCandidate` on it. The issue itself doesn't cause any problems besides an uncaught error.

**How to reproduce the issue:**
- make a phone call to an app using dart-sip-ua
- accept the call
- hang up the call on the caller side in the first 3 seconds after the call has been accepted

**Fix description**
I've just added a check inside `ready` function to check if session has been terminated. May be a better fix would be to store `ready` function on `rtc_session` and clear timer during session `close()`. What do you think?