### PR TITLE
Expose sendInfo from RTCSession to Call.sendInfo

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -432,6 +432,11 @@ class Call {
     _session.sendDTMF(tones, options);
   }
 
+  void sendInfo(String contentType, String body, Map<String, dynamic> options) {
+    assert(_session != null, 'ERROR(sendInfo): rtc session is invalid');
+    _session.sendInfo(contentType, body, options);
+  }
+
   String get remote_display_name {
     assert(_session != null,
         'ERROR(get remote_identity): rtc session is invalid!');


### PR DESCRIPTION
Fix for https://github.com/flutter-webrtc/dart-sip-ua/issues/185