### PR TITLE
Fix bug where stopping the SIPUAHelper caused a ConcurrentModificationError. Closes #282

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -759,7 +759,7 @@ class RTCSession extends EventManager implements Owner {
           _is_canceled = true;
           _cancel_reason = cancel_reason;
         } else if (_status == C.STATUS_1XX_RECEIVED) {
-          _request.cancel(cancel_reason ?? 'OK');
+          _request.cancel(cancel_reason);
         }
 
         _status = C.STATUS_CANCELED;

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -759,7 +759,7 @@ class RTCSession extends EventManager implements Owner {
           _is_canceled = true;
           _cancel_reason = cancel_reason;
         } else if (_status == C.STATUS_1XX_RECEIVED) {
-          _request.cancel(cancel_reason);
+          _request.cancel(cancel_reason ?? 'OK');
         }
 
         _status = C.STATUS_CANCELED;

--- a/lib/src/transactions/invite_client.dart
+++ b/lib/src/transactions/invite_client.dart
@@ -112,7 +112,7 @@ class InviteClientTransaction extends TransactionBase {
     transport!.send(ack);
   }
 
-  void cancel(String reason) {
+  void cancel(String? reason) {
     // Send only if a provisional response (>100) has been received.
     if (state != TransactionState.PROCEEDING) {
       return;

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -154,6 +154,9 @@ class UA extends EventManager {
 
   TransactionBag get transactions => _transactions;
 
+  // Flag that indicates whether UA is currently stopping
+  bool _stopping = false;
+
   // ============
   //  High Level API
   // ============
@@ -364,6 +367,8 @@ class UA extends EventManager {
       }
     });
 
+    _stopping = true;
+
     // Run  _close_ on every applicant.
     for (Applicant applicant in _applicants) {
       try {
@@ -505,6 +510,9 @@ class UA extends EventManager {
    *  Message
    */
   void newMessage(Message message, String originator, dynamic request) {
+    if (_stopping) {
+      return;
+    }
     _applicants.add(message);
     emit(EventNewMessage(
         message: message, originator: originator, request: request));
@@ -514,7 +522,11 @@ class UA extends EventManager {
    *  Options
    */
   void newOptions(Options message, String originator, dynamic request) {
+    if (_stopping) {
+      return;
+    }
     _applicants.add(message);
+
     emit(EventNewOptions(
         message: message, originator: originator, request: request));
   }
@@ -523,6 +535,9 @@ class UA extends EventManager {
    *  Message destroyed.
    */
   void destroyMessage(Message message) {
+    if (_stopping) {
+      return;
+    }
     _applicants.remove(message);
   }
 
@@ -530,6 +545,9 @@ class UA extends EventManager {
    *  Options destroyed.
    */
   void destroyOptions(Options message) {
+    if (_stopping) {
+      return;
+    }
     _applicants.remove(message);
   }
 


### PR DESCRIPTION
For further detail look into #282.

This also fixes a problem where when cancelling a phone call in the initiation stage would lead to an error, because cancel_reason would not yet be set. Now the default reason is OK