### PR TITLE
Update flutter_webrtc  to 0.9.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   crypto: ^3.0.0
-  flutter_webrtc: ^0.9.1
+  flutter_webrtc: ^0.9.9
   intl: ^0.17.0
   logger: ^1.0.0
   parser_error: ^0.2.0


### PR DESCRIPTION
Fix in 0.9.9: [Android] Support rtp transceiver direction type 4.