### PR TITLE
Allow setting ice_gathering_timeout option

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -240,6 +240,9 @@ class Checks {
       if (dtmf_mode == null) return;
       dst!.dtmf_mode = dtmf_mode;
     },
+    'ice_gathering_timeout': (Settings src, Settings? dst) {
+      dst!.ice_gathering_timeout = src.ice_gathering_timeout;
+    }
   };
 }
 

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -1673,7 +1673,9 @@ class RTCSession extends EventManager implements Owner {
            *  Because trickle ICE is not defined in the sip protocol, the delay of
            * initiating a call to answer the call waiting will be unacceptable.
            */
-          setTimeout(() => ready(), ua.configuration.ice_gathering_timeout);
+          if (ua.configuration.ice_gathering_timeout != 0) {
+            setTimeout(() => ready(), ua.configuration.ice_gathering_timeout);
+          }
         }
       }
     };


### PR DESCRIPTION
The default timeout of 500ms for gathering ice candidates can be too short in some cases. 
This change allows setting a different value or disabling the timeout.