### PR TITLE
Websocket message queue using streams and Delay between messages

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -61,7 +61,11 @@ class Settings {
 
   /// ICE Gathering Timeout (in millisecond).
   int ice_gathering_timeout = 500;
+
+  /// Sip Message Delay (in millisecond) ( default 0 ).
+  int sip_message_delay = 0;
 }
+
 
 // Configuration checks.
 class Checks {

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -116,9 +116,10 @@ class SIPUAHelper extends EventManager {
     // Reset settings
     _settings = Settings();
     WebSocketInterface socket = WebSocketInterface(
-        uaSettings.webSocketUrl, uaSettings.webSocketSettings);
+        uaSettings.webSocketUrl, messageDelay: _settings.sip_message_delay, webSocketSettings: uaSettings.webSocketSettings);
     _settings.sockets = <WebSocketInterface>[socket];
     _settings.uri = uaSettings.uri;
+    _settings.sip_message_delay = uaSettings.sip_message_delay;
     _settings.realm = uaSettings.realm;
     _settings.password = uaSettings.password;
     _settings.ha1 = uaSettings.ha1;
@@ -698,7 +699,8 @@ class UaSettings {
 
   /// ICE Gathering Timeout, default 500ms
   int iceGatheringTimeout = 500;
-
+  /// Sip Message Delay (in millisecond) (default 0).
+  int sip_message_delay = 0;
   List<Map<String, String>> iceServers = <Map<String, String>>[
     <String, String>{'url': 'stun:stun.l.google.com:19302'},
 // turn server configuration example.

--- a/lib/src/transports/websocket_interface.dart
+++ b/lib/src/transports/websocket_interface.dart
@@ -7,7 +7,11 @@ import 'websocket_dart_impl.dart'
     if (dart.library.js) 'websocket_web_impl.dart';
 
 class WebSocketInterface implements Socket {
-  WebSocketInterface(String url, [WebSocketSettings? webSocketSettings]) {
+  final int _messageDelay;
+
+  WebSocketInterface(String url,
+      {required int messageDelay, WebSocketSettings? webSocketSettings})
+      : _messageDelay = messageDelay {
     logger.d('new() [url:$url]');
     _url = url;
     dynamic parsed_url = Grammar.parse(url, 'absoluteURI');
@@ -83,7 +87,7 @@ class WebSocketInterface implements Socket {
     }
     logger.d('connecting to WebSocket $_url');
     try {
-      _ws = WebSocketImpl(_url!);
+      _ws = WebSocketImpl(_url!, _messageDelay);
 
       _ws!.onOpen = () {
         _closed = false;


### PR DESCRIPTION
After INVITE from an app, server sends proxy-authorization challenge and app sends ACK and INVITE with proxy-authorization. However sometimes the Server doesn't recieve the second invite(It recieves the ACK tho). The delay fixes this issue, possibly because server needs delay between these two messages.