### PR TITLE
fixed error handling in _receiveInviteResponse

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -2354,7 +2354,7 @@ class RTCSession extends EventManager implements Owner {
           RTCSessionDescription(response.body, 'answer');
 
       try {
-        _connection!.setRemoteDescription(answer);
+        await _connection!.setRemoteDescription(answer);
       } catch (error) {
         logger.e(
             'emit "peerconnection:setremotedescriptionfailed" [error:${error.toString()}]');


### PR DESCRIPTION
There were no "await" keyword in front on "_connection!.setRemoteDescription(answer)" so this caused throwing unhandled exception