### PR TITLE
fix(hangup): set cancel reason nullable

### DIFF
--- a/lib/src/sip_message.dart
+++ b/lib/src/sip_message.dart
@@ -309,7 +309,7 @@ class InitialOutgoingInviteRequest extends OutgoingRequest {
     transaction = null;
   }
 
-  void cancel(String reason) {
+  void cancel(String? reason) {
     transaction.cancel(reason);
   }
 


### PR DESCRIPTION
Should fix the issue of not being able to hang up on an incoming call.: close https://github.com/flutter-webrtc/dart-sip-ua/issues/255
