### PR TITLE
Hold fix

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -1611,6 +1611,12 @@ class RTCSession extends EventManager implements Owner {
     Completer<RTCSessionDescription> completer =
         Completer<RTCSessionDescription>();
 
+    constraints = constraints ??
+        <String, dynamic>{
+          'mandatory': <String, dynamic>{},
+          'optional': <String, dynamic>{},
+        };
+
     if (type != 'offer' && type != 'answer') {
       completer.completeError(Exceptions.TypeError(
           'createLocalDescription() | invalid type "$type"'));

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -1550,8 +1550,11 @@ class RTCSession extends EventManager implements Owner {
   }
 
   void _iceRestart() async {
-    Map<String, dynamic> offerConstraints =
-        _rtcOfferConstraints ?? <String, dynamic>{};
+    Map<String, dynamic> offerConstraints = _rtcOfferConstraints ??
+        <String, dynamic>{
+          'mandatory': <String, dynamic>{},
+          'optional': <String, dynamic>{},
+        };
     offerConstraints['mandatory']['IceRestart'] = true;
     renegotiate(offerConstraints);
   }


### PR DESCRIPTION
Should fix #339 
These issues are caused by the exzessive use of Map<String, dynamic> to pass parameters. All of these should be replaced by proper dart classes that contain the possible fields. 