### PR TITLE
Allow await on helper start call

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -110,7 +110,7 @@ class SIPUAHelper extends EventManager {
     return _calls[id];
   }
 
-  void start(UaSettings uaSettings) async {
+  Future<void> start(UaSettings uaSettings) async {
     if (_ua != null) {
       logger.w('UA instance already exist!, stopping UA and creating a one...');
       _ua!.stop();


### PR DESCRIPTION
Because the return value of start is void rather than Future<void> it is impossible to await it's completion because it has been flagged as async.

Users choosing to allow the call to be completed asynchronously can simply ignore the Future<void> but those wanting to act after registration is complete cannot do so without this change.