### PR TITLE
Add status code to CallState on the progress event

### DIFF
--- a/lib/src/event_manager/call_events.dart
+++ b/lib/src/event_manager/call_events.dart
@@ -31,10 +31,12 @@ class EventCallEnded extends CallEvent {
 }
 
 class EventCallProgress extends CallEvent {
-  EventCallProgress({RTCSession? session, this.originator, this.response})
+  EventCallProgress(
+      {RTCSession? session, this.originator, this.response, this.cause})
       : super(session);
   String? originator;
   dynamic response;
+  ErrorCause? cause;
 }
 
 class EventCallConfirmed extends CallEvent {

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -2361,7 +2361,7 @@ class RTCSession extends EventManager implements Owner {
       }
 
       _status = C.STATUS_1XX_RECEIVED;
-      _progress('remote', response);
+      _progress('remote', response, int.parse(status_code));
 
       if (response.body == null || response.body!.isEmpty) {
         return;
@@ -2916,11 +2916,17 @@ class RTCSession extends EventManager implements Owner {
     emit(EventCallConnecting(session: this, request: request));
   }
 
-  void _progress(String originator, dynamic response) {
+  void _progress(String originator, dynamic response, [int? status_code]) {
     logger.d('session progress');
     logger.d('emit "progress"');
+
+    ErrorCause errorCause = ErrorCause(status_code: status_code);
+
     emit(EventCallProgress(
-        session: this, originator: originator, response: response));
+        session: this,
+        originator: originator,
+        response: response,
+        cause: errorCause));
   }
 
   void _accepted(String originator, [dynamic message]) {

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -228,8 +228,10 @@ class SIPUAHelper extends EventManager {
     });
     handlers.on(EventCallProgress(), (EventCallProgress event) {
       logger.d('call is in progress');
-      _notifyCallStateListeners(event,
-          CallState(CallStateEnum.PROGRESS, originator: event.originator));
+      _notifyCallStateListeners(
+          event,
+          CallState(CallStateEnum.PROGRESS,
+              originator: event.originator, cause: event.cause));
     });
     handlers.on(EventCallFailed(), (EventCallFailed event) {
       logger.d('call failed with cause: ${event.cause}');


### PR DESCRIPTION
Sometimes we want to check whether the "progress" event has early media (183 Session Progress) or not (180 Ringing) to controll a ring back tone playback. This change will provide the status code via CallState.cause.
