### PR TITLE
expose rtc_session to/from-tag

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -88,7 +88,9 @@ class RTCSession extends EventManager implements Owner {
   final Map<String?, Dialog> _earlyDialogs = <String?, Dialog>{};
   String? _contact;
   String? _from_tag;
+  String? get from_tag => _from_tag;
   String? _to_tag;
+  String? get to_tag => _to_tag;
 
   // The RTCPeerConnection instance (public attribute).
   RTCPeerConnection? _connection;


### PR DESCRIPTION
Hello,
the goal for this PR is to provide everything we need to to an attended transfer, which we're not able to do right now.
The sessions refer method exposes an `option` parameter where we can set the `replaces`-headers.

Right now we can't access the sessions to_tag and from_tag which are required in the replaces header to do an attended transfer.

For now I would suggest to expose the to_tag and from_tag only. 
This would provide the necessary information for an attended transfer and gives us freedom to implement the attended transfer ourself.

Related issues:
- https://github.com/flutter-webrtc/dart-sip-ua/issues/364
- https://github.com/flutter-webrtc/dart-sip-ua/issues/198

