### PR TITLE
allow to change UA uri in runtime

### DIFF
--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -350,6 +350,10 @@ class SIPUAHelper extends EventManager {
     return defaultOptions;
   }
 
+  bool setUAParam(String parameter, dynamic value) {
+    return _ua!.set(parameter, value);
+  }
+
   Message sendMessage(String target, String body,
       [Map<String, dynamic>? options, Map<String, dynamic>? params]) {
     return _ua!.sendMessage(target, body, options, params);

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -431,6 +431,12 @@ class UA extends EventManager {
           break;
         }
 
+      case 'uri':
+        {
+          _configuration.uri = value;
+          break;
+        }
+
       default:
         logger.e('set() | cannot set "$parameter" parameter in runtime');
 


### PR DESCRIPTION
* allows to change `uri` configuration parameter for `UA` without instance reload
* allows to set `UA` dynamic parameters from `SIPUAHelper`

useful to set `From` header display name and URI parts before the call.
example:
```
sip_ua_helper = SIPUAHelper();
...
sip_ua_helper.setUAParam('display_name','test');
sip_ua_helper.setUAParam('uri', URI('sip','42','domain.invalid'));
sip_ua_helper.call(target);
```