### PR TITLE
Uri configuration for call operation

### DIFF
--- a/lib/sip_ua.dart
+++ b/lib/sip_ua.dart
@@ -1,3 +1,5 @@
 export 'src/enum_helper.dart';
 export 'src/sip_ua_helper.dart';
 export 'src/transport_type.dart';
+export 'src/uri.dart';
+

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -306,6 +306,16 @@ class RTCSession extends EventManager implements Owner {
     _ua.contact!.outbound = true;
     _contact = _ua.contact.toString();
 
+    bool isFromUriOptionPresent = options['from_uri'] != null;
+
+    //set from_uri and from_display_name if present
+    if (isFromUriOptionPresent) {
+      requestParams['from_display_name'] = options['from_display_name'] ?? '';
+      requestParams['from_uri'] = URI.parse(options['from_uri']);
+      extraHeaders
+        .add('P-Preferred-Identity: ${_ua.configuration.uri.toString()}');
+    }
+
     if (anonymous) {
       requestParams['from_display_name'] = 'Anonymous';
       requestParams['from_uri'] = URI('sip', 'anonymous', 'anonymous.invalid');


### PR DESCRIPTION
Allows to set custom from_uri & from_display_name for call operation using customOptions parameter.

```
Future<void> initiateCall(String target) async {
    Map<String, String> customOptions = {};

      var currentCallerId = '186455555'

        customOptions['from_uri'] =
            URI('sip', currentCallerId, _config.domain).toString();
        customOptions['from_display_name'] = 'User Name'
   
      var mediaStream = await navigator.mediaDevices.getUserMedia(
          _mediaConstraints);

      _helper.call(target, voiceonly: true,
          mediaStream: mediaStream,
          customOptions: customOptions);
  }
```

**From: "User Name" <sip:186455555@sip.x.systems>;tag=52rmnxgcmt**