### PR TITLE
Set transport value using socket via_transport 

### DIFF
--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -880,7 +880,13 @@ class UA extends EventManager {
     // User no_answer_timeout.
     _configuration.no_answer_timeout *= 1000;
 
+    //Default transport initialization
     String transport = _configuration.transportType?.name ?? 'WS';
+
+    //Override transport from socket
+    if(transport == 'WS' && _socketTransport != null){
+      transport = _socketTransport!.via_transport;
+    }
 
     // Via Host.
     if (_configuration.contact_uri != null) {


### PR DESCRIPTION
Seems we found an issue in case of using WSS transport. In that case 'Contact' header contains 'ws' value instead of 'wss'. 
```Contact: <sip:lovxxb@k87kr43mm.invalid;transport=WS;ob>```

It leads to call issue: 'Failed to set remote offer sdp: Called with SDP without DTLS fingerprint'

We suppose it is regression after implementation TransportType.  Previously transport initialized using socket via_transport value ( ws | wss, depends on transport ). Currently it initializes using just TransportType enum value (ws, tcp), which does not cover the wss usage scenario.

https://github.com/flutter-webrtc/dart-sip-ua/commit/024d0e847dba866e7ff80ce1c518091fe0e7496c#diff-28c3dd474c00b015a64df65906a721293e92dba454e56886f0cb3de9701baf96L856-L861

