### PR TITLE
Upgrade to video call implementation and dark mode 2

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,10 @@
+import 'package:dart_sip_ua_example/src/theme_provider.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:provider/provider.dart';
 import 'package:sip_ua/sip_ua.dart';
 
 import 'src/about.dart';
@@ -10,10 +13,16 @@ import 'src/dialpad.dart';
 import 'src/register.dart';
 
 void main() {
+  Logger.level = Level.warning;
   if (WebRTC.platformIsDesktop) {
     debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
   }
-  runApp(MyApp());
+  runApp(
+    MultiProvider(
+      providers: [ChangeNotifierProvider(create: (_) => ThemeProvider())],
+      child: MyApp(),
+    ),
+  );
 }
 
 typedef PageContentBuilder = Widget Function(
@@ -53,22 +62,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        fontFamily: 'Roboto',
-        inputDecorationTheme: InputDecorationTheme(
-          hintStyle: TextStyle(color: Colors.grey),
-          contentPadding: EdgeInsets.all(10.0),
-          border: UnderlineInputBorder(
-              borderSide: BorderSide(color: Colors.black12)),
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            padding: const EdgeInsets.all(16),
-            textStyle: TextStyle(fontSize: 18),
-          ),
-        ),
-      ),
+      theme: Provider.of<ThemeProvider>(context).currentTheme,
       initialRoute: '/',
       onGenerateRoute: _onGenerateRoute,
     );

--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -143,6 +143,15 @@ class _MyRegisterWidget extends State<RegisterWidget>
 
   @override
   Widget build(BuildContext context) {
+    Color? textColor = Theme.of(context).textTheme.bodyMedium?.color;
+    Color? textFieldFill =
+        Theme.of(context).buttonTheme.colorScheme?.surfaceContainerLowest;
+    OutlineInputBorder border = OutlineInputBorder(
+      borderSide: BorderSide.none,
+      borderRadius: BorderRadius.circular(5),
+    );
+    Color? textLabelColor =
+        Theme.of(context).textTheme.bodyMedium?.color?.withOpacity(0.5);
     return Scaffold(
       appBar: AppBar(
         title: Text("SIP Account"),
@@ -153,12 +162,13 @@ class _MyRegisterWidget extends State<RegisterWidget>
           Center(
             child: Text(
               'Register Status: ${EnumHelper.getName(_registerState.state)}',
-              style: TextStyle(fontSize: 18, color: Colors.black54),
+              style: TextStyle(fontSize: 18, color: textColor),
             ),
           ),
-          SizedBox(height: 20),
+          SizedBox(height: 15),
           if (_selectedTransport == TransportType.WS) ...[
-            Text('WebSocket:'),
+            Text('WebSocket', style: TextStyle(color: textLabelColor)),
+            SizedBox(height: 5),
             TextFormField(
               controller: _wsUriController,
               keyboardType: TextInputType.text,
@@ -167,51 +177,85 @@ class _MyRegisterWidget extends State<RegisterWidget>
             ),
           ],
           if (_selectedTransport == TransportType.TCP) ...[
-            Text('Port:'),
+            Text('Port', style: TextStyle(color: textLabelColor)),
+            SizedBox(height: 5),
             TextFormField(
               controller: _portController,
               keyboardType: TextInputType.text,
               textAlign: TextAlign.center,
+              decoration: InputDecoration(
+                filled: true,
+                fillColor: textFieldFill,
+                border: border,
+                enabledBorder: border,
+                focusedBorder: border,
+              ),
             ),
           ],
-          SizedBox(height: 20),
-          Text('SIP URI:'),
+          SizedBox(height: 15),
+          Text('SIP URI', style: TextStyle(color: textLabelColor)),
+          SizedBox(height: 5),
           TextFormField(
             controller: _sipUriController,
             keyboardType: TextInputType.text,
             autocorrect: false,
             textAlign: TextAlign.center,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: textFieldFill,
+              border: border,
+              enabledBorder: border,
+              focusedBorder: border,
+            ),
           ),
-          SizedBox(height: 20),
-          Text('Authorization User:'),
+          SizedBox(height: 15),
+          Text('Authorization User', style: TextStyle(color: textLabelColor)),
+          SizedBox(height: 5),
           TextFormField(
             controller: _authorizationUserController,
             keyboardType: TextInputType.text,
             autocorrect: false,
             textAlign: TextAlign.center,
             decoration: InputDecoration(
+              filled: true,
+              fillColor: textFieldFill,
+              border: border,
+              enabledBorder: border,
+              focusedBorder: border,
               hintText:
                   _authorizationUserController.text.isEmpty ? '[Empty]' : null,
             ),
           ),
-          SizedBox(height: 20),
-          Text('Password:'),
+          SizedBox(height: 15),
+          Text('Password', style: TextStyle(color: textLabelColor)),
+          SizedBox(height: 5),
           TextFormField(
             controller: _passwordController,
             keyboardType: TextInputType.text,
             autocorrect: false,
             textAlign: TextAlign.center,
             decoration: InputDecoration(
+              filled: true,
+              fillColor: textFieldFill,
+              border: border,
+              enabledBorder: border,
+              focusedBorder: border,
               hintText: _passwordController.text.isEmpty ? '[Empty]' : null,
             ),
           ),
-          SizedBox(height: 20),
-          Text('Display Name:'),
+          SizedBox(height: 15),
+          Text('Display Name', style: TextStyle(color: textLabelColor)),
+          SizedBox(height: 5),
           TextFormField(
             controller: _displayNameController,
             keyboardType: TextInputType.text,
             textAlign: TextAlign.center,
             decoration: InputDecoration(
+              filled: true,
+              fillColor: textFieldFill,
+              border: border,
+              enabledBorder: border,
+              focusedBorder: border,
               hintText: _displayNameController.text.isEmpty ? '[Empty]' : null,
             ),
           ),
@@ -263,5 +307,10 @@ class _MyRegisterWidget extends State<RegisterWidget>
   @override
   void onNewNotify(Notify ntf) {
     // NO OP
+  }
+
+  @override
+  void onNewReinvite(ReInvite event) {
+    // TODO: implement onNewReinvite
   }
 }

--- a/example/lib/src/theme_provider.dart
+++ b/example/lib/src/theme_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeData? currentTheme;
+
+  ThemeProvider() {
+    final brightness = PlatformDispatcher.instance.platformBrightness;
+
+    currentTheme =
+        brightness == Brightness.dark ? ThemeData.dark() : ThemeData.light();
+  }
+
+  setLightMode() {
+    currentTheme = ThemeData(
+      primarySwatch: Colors.blue,
+      fontFamily: 'Roboto',
+      inputDecorationTheme: InputDecorationTheme(
+        hintStyle: TextStyle(color: Colors.grey),
+        contentPadding: EdgeInsets.all(10.0),
+        border:
+            UnderlineInputBorder(borderSide: BorderSide(color: Colors.black12)),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          padding: const EdgeInsets.all(16),
+          textStyle: TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+    notifyListeners();
+  }
+
+  setDarkmode() {
+    currentTheme = ThemeData.dark().copyWith(
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          padding: const EdgeInsets.all(16),
+          textStyle: TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+    notifyListeners();
+  }
+}

--- a/example/lib/src/widgets/action_button.dart
+++ b/example/lib/src/widgets/action_button.dart
@@ -29,6 +29,10 @@ class ActionButton extends StatefulWidget {
 class _ActionButtonState extends State<ActionButton> {
   @override
   Widget build(BuildContext context) {
+    Color? background =
+        Theme.of(context).buttonTheme.colorScheme?.surfaceContainerLow;
+    Color splashColor = Theme.of(context).splashColor;
+    Color? textColor = Theme.of(context).textTheme.bodyMedium?.color;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.start,
@@ -40,9 +44,9 @@ class _ActionButtonState extends State<ActionButton> {
             child: RawMaterialButton(
               onPressed: widget.onPressed,
               splashColor: widget.fillColor ??
-                  (widget.checked ? Colors.white : Colors.blue),
+                  (widget.checked ? splashColor : Colors.blue),
               fillColor: widget.fillColor ??
-                  (widget.checked ? Colors.blue : Colors.white),
+                  (widget.checked ? Colors.blue : background),
               elevation: 10.0,
               shape: CircleBorder(),
               child: Padding(
@@ -54,12 +58,12 @@ class _ActionButtonState extends State<ActionButton> {
                             Text('${widget.title}',
                                 style: TextStyle(
                                   fontSize: 18,
-                                  color: widget.fillColor ?? Colors.grey[500],
+                                  color: widget.fillColor ?? textColor,
                                 )),
                             Text(widget.subTitle.toUpperCase(),
                                 style: TextStyle(
                                   fontSize: 8,
-                                  color: widget.fillColor ?? Colors.grey[500],
+                                  color: widget.fillColor ?? textColor,
                                 ))
                           ])
                     : Icon(
@@ -82,7 +86,7 @@ class _ActionButtonState extends State<ActionButton> {
                         widget.title!,
                         style: TextStyle(
                           fontSize: 15.0,
-                          color: widget.fillColor ?? Colors.grey[500],
+                          color: widget.fillColor ?? textColor,
                         ),
                       ),
               )

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   shared_preferences: ^2.2.0
   permission_handler: ^11.1.0
   flutter_webrtc: ^0.10.4
+  provider: 6.1.2
+  logger: ^2.4.0
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -66,6 +66,8 @@ class Settings {
   /// ICE Gathering Timeout (in millisecond).
   int ice_gathering_timeout = 500;
 
+  bool terminateOnAudioMediaPortZero = false;
+
   /// Sip Message Delay (in millisecond) ( default 0 ).
   int sip_message_delay = 0;
 }

--- a/lib/src/event_manager/internal_events.dart
+++ b/lib/src/event_manager/internal_events.dart
@@ -97,10 +97,13 @@ class EventUpdate extends EventType {
   bool Function(Map<String, dynamic> options)? reject;
 }
 
-class EventReinvite extends EventType {
-  EventReinvite({this.request, this.callback, this.reject});
+class EventReInvite extends EventType {
+  EventReInvite(
+      {this.request, this.callback, this.reject, this.hasAudio, this.hasVideo});
   dynamic request;
-  bool Function(Map<String, dynamic> options)? callback;
+  bool? hasAudio;
+  bool? hasVideo;
+  Future<bool> Function(Map<String, dynamic> options)? callback;
   bool Function(Map<String, dynamic> options)? reject;
 }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -80,15 +80,20 @@ IncomingMessage? parseMessage(String data, UA? ua) {
    * beyond the end of the body, they MUST be discarded.
    */
   if (message.hasHeader('content-length')) {
-    dynamic contentLength = message.getHeader('content-length');
+    dynamic headerContentLength = message.getHeader('content-length');
 
-    if (contentLength is String) {
-      contentLength = int.tryParse(contentLength) ?? 0;
+    if (headerContentLength is String) {
+      headerContentLength = int.tryParse(headerContentLength) ?? 0;
     }
-    contentLength ??= 0;
-    if (contentLength > 0) {
-      List<int> encoded = utf8.encode(data.substring(bodyStart));
-      List<int> content = encoded.sublist(0, contentLength as int);
+    headerContentLength ??= 0;
+
+    if (headerContentLength > 0) {
+      List<int> actualContent = utf8.encode(data.substring(bodyStart));
+      if (headerContentLength != actualContent.length)
+        logger.w(
+            '${message.method} received with content-length: $headerContentLength but actual length is: ${actualContent.length}');
+      List<int> encodedBody = utf8.encode(data.substring(bodyStart));
+      List<int> content = encodedBody.sublist(0, actualContent.length);
       message.body = utf8.decode(content);
     }
   } else {

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -256,6 +256,7 @@ class RTCSession extends EventManager implements Owner {
     _rtcAnswerConstraints =
         options['rtcAnswerConstraints'] ?? <String, dynamic>{};
     data = options['data'] ?? data;
+    data?['video'] = !(options['mediaConstraints']['video'] == false);
 
     // Check target.
     if (target == null) {
@@ -629,9 +630,7 @@ class RTCSession extends EventManager implements Owner {
     }
 
     // Set remote description.
-    if (_late_sdp) {
-      return;
-    }
+    if (_late_sdp) return;
 
     logger.d('emit "sdp"');
     emit(EventSdp(originator: 'remote', type: 'offer', sdp: request.body));
@@ -1123,13 +1122,23 @@ class RTCSession extends EventManager implements Owner {
     return true;
   }
 
-  bool renegotiate([Map<String, dynamic>? options, Function? done]) {
+  bool renegotiate(
+      {Map<String, dynamic>? options,
+      Function(IncomingMessage)? done,
+      bool useUpdate = false}) {
     logger.d('renegotiate()');
 
     options = options ?? <String, dynamic>{};
+    EventManager handlers = options['eventHandlers'] ?? EventManager();
 
     Map<String, dynamic>? rtcOfferConstraints =
         options['rtcOfferConstraints'] ?? _rtcOfferConstraints;
+
+    Map<String, dynamic> mediaConstraints =
+        options['mediaConstraints'] ?? <String, dynamic>{};
+
+    dynamic sdpSemantics =
+        options['pcConfig']?['sdpSemantics'] ?? 'unified-plan';
 
     if (_status != C.STATUS_WAITING_FOR_ACK && _status != C.STATUS_CONFIRMED) {
       return false;
@@ -1139,10 +1148,9 @@ class RTCSession extends EventManager implements Owner {
       return false;
     }
 
-    EventManager handlers = EventManager();
     handlers.on(EventSucceeded(), (EventSucceeded event) {
-      if (done != null) {
-        done();
+      if (done != null && event.response != null) {
+        done(event.response!);
       }
     });
 
@@ -1156,7 +1164,7 @@ class RTCSession extends EventManager implements Owner {
 
     _setLocalMediaStatus();
 
-    if (options['useUpdate'] != null) {
+    if (useUpdate) {
       _sendUpdate(<String, dynamic>{
         'sdpOffer': true,
         'eventHandlers': handlers,
@@ -1166,7 +1174,9 @@ class RTCSession extends EventManager implements Owner {
     } else {
       _sendReinvite(<String, dynamic>{
         'eventHandlers': handlers,
+        'sdpSemantics': sdpSemantics,
         'rtcOfferConstraints': rtcOfferConstraints,
+        'mediaConstraints': mediaConstraints,
         'extraHeaders': options['extraHeaders']
       });
     }
@@ -1571,7 +1581,20 @@ class RTCSession extends EventManager implements Owner {
           'optional': <dynamic>[],
         };
     offerConstraints['mandatory']['IceRestart'] = true;
-    renegotiate(offerConstraints);
+
+    EventManager handlers = EventManager();
+    handlers.on(EventSucceeded(), (EventSucceeded event) async {
+      logger.d('ICE Restart was successful');
+    });
+    handlers.on(EventCallFailed(), (EventCallFailed event) {
+      terminate(<String, dynamic>{
+        'cause': DartSIP_C.CausesType.WEBRTC_ERROR,
+        'status_code': 500,
+        'reason_phrase': 'Media Renegotiation Failed'
+      });
+    });
+    offerConstraints['eventHandlers'] = handlers;
+    renegotiate(options: offerConstraints);
   }
 
   Future<void> _createRTCConnection(Map<String, dynamic> pcConfig,
@@ -1636,7 +1659,7 @@ class RTCSession extends EventManager implements Owner {
         modifiers = constraints['offerModifiers'] ??
             <Future<RTCSessionDescription> Function(RTCSessionDescription)>[];
 
-    constraints['offerModifiers'] = null;
+    constraints.remove('offerModifiers');
 
     if (type != 'offer' && type != 'answer') {
       completer.completeError(Exceptions.TypeError(
@@ -1803,37 +1826,7 @@ class RTCSession extends EventManager implements Owner {
   /// In dialog INVITE Reception
   void _receiveReinvite(IncomingRequest request) async {
     logger.d('receiveReinvite()');
-
     String? contentType = request.getHeader('Content-Type');
-    bool rejected = false;
-
-    bool reject(dynamic options) {
-      rejected = true;
-
-      int status_code = options['status_code'] ?? 403;
-      String reason_phrase = options['reason_phrase'] ?? '';
-      List<dynamic> extraHeaders = utils.cloneArray(options['extraHeaders']);
-
-      if (_status != C.STATUS_CONFIRMED) {
-        return false;
-      }
-
-      if (status_code < 300 || status_code >= 700) {
-        throw Exceptions.TypeError('Invalid status_code: $status_code');
-      }
-
-      request.reply(status_code, reason_phrase, extraHeaders);
-      return true;
-    }
-
-    // Emit 'reinvite'.
-    emit(EventReinvite(request: request, callback: null, reject: reject));
-
-    if (rejected) {
-      return;
-    }
-
-    _late_sdp = false;
 
     void sendAnswer(String? sdp) async {
       List<String> extraHeaders = <String>['Contact: $_contact'];
@@ -1856,6 +1849,8 @@ class RTCSession extends EventManager implements Owner {
       }
     }
 
+    _late_sdp = false;
+
     // Request without SDP.
     if (request.body == null) {
       _late_sdp = true;
@@ -1870,23 +1865,66 @@ class RTCSession extends EventManager implements Owner {
       return;
     }
 
-    // Request with SDP.
+    // Request without SDP.
     if (contentType != 'application/sdp') {
       logger.d('invalid Content-Type');
       request.reply(415);
       return;
     }
 
-    try {
-      RTCSessionDescription desc = await _processInDialogSdpOffer(request);
-      // Send answer.
-      if (_status == C.STATUS_TERMINATED) {
-        return;
+    bool reject(dynamic options) {
+      int status_code = options['status_code'] ?? 403;
+      String? reason_phrase = options['reason_phrase'];
+      List<dynamic> extraHeaders = utils.cloneArray(options['extraHeaders']);
+
+      if (_status != C.STATUS_CONFIRMED) {
+        return false;
       }
-      sendAnswer(desc.sdp);
-    } catch (error) {
-      logger.e('Got anerror on re-INVITE: ${error.toString()}');
+
+      if (status_code < 300 || status_code >= 700) {
+        throw Exceptions.TypeError('Invalid status_code: $status_code');
+      }
+      print('Rejecting with status code: $status_code, reason: $reason_phrase');
+      request.reply(status_code, reason_phrase, extraHeaders);
+      return true;
     }
+
+    RTCSessionDescription? desc = await _processInDialogSdpOffer(request);
+
+    Future<bool> acceptReInvite(dynamic options) async {
+      try {
+        // Send answer.
+        if (_status == C.STATUS_TERMINATED) {
+          return false;
+        }
+        sendAnswer(desc.sdp);
+      } catch (error) {
+        logger.e('Got anerror on re-INVITE: ${error.toString()}');
+      }
+
+      return true;
+    }
+
+    String body = request.body ?? '';
+    bool hasAudio = false;
+    bool hasVideo = false;
+    if (request.sdp == null && body.isNotEmpty) {
+      request.sdp = sdp_transform.parse(body);
+    }
+    List<dynamic> media = request.sdp?['media'];
+    for (Map<String, dynamic> m in media) {
+      if (m['type'] == 'audio') {
+        hasAudio = true;
+      } else if (m['type'] == 'video') {
+        hasVideo = true;
+      }
+    }
+    emit(EventReInvite(
+        request: request,
+        hasAudio: hasAudio,
+        hasVideo: hasVideo,
+        callback: acceptReInvite,
+        reject: reject));
   }
 
   /**
@@ -1961,10 +1999,16 @@ class RTCSession extends EventManager implements Owner {
     Map<String, dynamic>? sdp = request.parseSDP();
 
     bool hold = false;
+    bool upgradeToVideo = false;
     if (sdp != null) {
-      for (Map<String, dynamic> m in sdp['media']) {
+      List<dynamic> mediaList = sdp['media'];
+      for (Map<String, dynamic> m in mediaList) {
         if (holdMediaTypes.indexOf(m['type']) == -1) {
           continue;
+        }
+
+        if (m['type'] == 'video') {
+          upgradeToVideo = true;
         }
 
         String direction = m['direction'] ?? sdp['direction'] ?? 'sendrecv';
@@ -1975,9 +2019,35 @@ class RTCSession extends EventManager implements Owner {
         // If at least one of the streams is active don't emit 'hold'.
         else {
           hold = false;
-          break;
         }
       }
+    }
+
+    if (upgradeToVideo) {
+      Map<String, dynamic> mediaConstraints = <String, dynamic>{
+        'audio': true,
+        'video': <String, dynamic>{
+          'mandatory': <String, dynamic>{
+            'minWidth': '640',
+            'minHeight': '480',
+            'minFrameRate': '30',
+          },
+          'facingMode': 'user',
+        }
+      };
+      MediaStream localStream =
+          await navigator.mediaDevices.getUserMedia(mediaConstraints);
+      if (localStream.getVideoTracks().isEmpty) {
+        logger.w(
+            'Remote wants to upgrade to video but failed to get local video');
+      }
+      for (MediaStreamTrack track in localStream.getTracks()) {
+        if (track.kind == 'video') {
+          _connection!.addTrack(track, localStream);
+        }
+      }
+      emit(
+          EventStream(session: this, originator: 'local', stream: localStream));
     }
 
     logger.d('emit "sdp"');
@@ -2312,11 +2382,17 @@ class RTCSession extends EventManager implements Owner {
 
   /// Reception of Response for Initial INVITE
   void _receiveInviteResponse(IncomingResponse? response) async {
-    logger.d('receiveInviteResponse()');
+    logger.d('receiveInviteResponse()  current status: $_status ');
+
+    if (response == null) {
+      logger.d('No response received');
+      return;
+    }
+    response.sdp = sdp_transform.parse(response.body ?? '');
 
     /// Handle 2XX retransmissions and responses from forked requests.
     if (_dialog != null &&
-        (response!.status_code >= 200 && response.status_code <= 299)) {
+        (response.status_code >= 200 && response.status_code <= 299)) {
       ///
       /// If it is a retransmission from the endpoint that established
       /// the dialog, send an ACK
@@ -2343,7 +2419,7 @@ class RTCSession extends EventManager implements Owner {
 
     // Proceed to cancellation if the user requested.
     if (_is_canceled) {
-      if (response!.status_code >= 100 && response.status_code < 200) {
+      if (response.status_code >= 100 && response.status_code < 200) {
         _request.cancel(_cancel_reason);
       } else if (response.status_code >= 200 && response.status_code < 299) {
         _acceptAndTerminate(response);
@@ -2355,7 +2431,7 @@ class RTCSession extends EventManager implements Owner {
       return;
     }
 
-    String status_code = response!.status_code.toString();
+    String status_code = response.status_code.toString();
 
     if (utils.test100(status_code)) {
       // 100 trying
@@ -2397,9 +2473,6 @@ class RTCSession extends EventManager implements Owner {
         emit(EventSetRemoteDescriptionFailed(exception: error));
       }
     } else if (utils.test2XX(status_code)) {
-      // 2XX
-      _status = C.STATUS_CONFIRMED;
-
       if (response.body == null || response.body!.isEmpty) {
         _acceptAndTerminate(response, 400, DartSIP_C.CausesType.MISSING_SDP);
         _failed('remote', null, null, response, 400,
@@ -2407,10 +2480,21 @@ class RTCSession extends EventManager implements Owner {
         return;
       }
 
+      dynamic mediaPort = response.sdp?['media'][0]['port'] ?? 0;
+
+      if (mediaPort == 0 && _ua.configuration.terminateOnAudioMediaPortZero) {
+        _acceptAndTerminate(response, 400, DartSIP_C.CausesType.MISSING_SDP);
+        _failed('remote', null, null, response, 400,
+            DartSIP_C.CausesType.BAD_MEDIA_DESCRIPTION, 'Media port is zero');
+        return;
+      }
+
       // An error on dialog creation will fire 'failed' event.
       if (_createDialog(response, 'UAC') == null) {
         return;
       }
+
+      _status = C.STATUS_CONFIRMED;
 
       logger.d('emit "sdp"');
       emit(EventSdp(originator: 'remote', type: 'answer', sdp: response.body));
@@ -2478,6 +2562,56 @@ class RTCSession extends EventManager implements Owner {
     Map<String, dynamic>? rtcOfferConstraints =
         options['rtcOfferConstraints'] ?? _rtcOfferConstraints;
 
+    Map<String, dynamic> mediaConstraints =
+        options['mediaConstraints'] ?? <String, dynamic>{};
+
+    dynamic sdpSemantics =
+        options['pcConfig']?['sdpSemantics'] ?? 'unified-plan';
+
+    bool hasVideo = (options['mediaConstraints']?['video'] ?? false) != false;
+
+    try {
+      MediaStream localStream =
+          await navigator.mediaDevices.getUserMedia(mediaConstraints);
+      _localMediaStreamLocallyGenerated = true;
+      _localMediaStream = localStream;
+
+      emit(
+          EventStream(session: this, originator: 'local', stream: localStream));
+
+      switch (sdpSemantics) {
+        case 'unified-plan':
+          localStream.getTracks().forEach((MediaStreamTrack track) {
+            if (track.kind == 'video' && hasVideo) {
+              _connection!.addTrack(track, localStream);
+            }
+          });
+          break;
+        case 'plan-b':
+          _connection!.addStream(localStream);
+          break;
+        default:
+          logger.e('Unkown sdp semantics $sdpSemantics');
+          throw Exceptions.NotReadyError('Unkown sdp semantics $sdpSemantics');
+      }
+    } catch (error) {
+      if (_status == C.STATUS_TERMINATED) {
+        throw Exceptions.InvalidStateError('terminated');
+      }
+      request.reply(480);
+      _failed(
+          'local',
+          null,
+          null,
+          null,
+          480,
+          DartSIP_C.CausesType.USER_DENIED_MEDIA_ACCESS,
+          'User Denied Media Access');
+      logger.e('emit "getusermediafailed" [error:${error.toString()}]');
+      emit(EventGetUserMediaFailed(exception: error));
+      throw Exceptions.InvalidStateError('getUserMedia() failed');
+    }
+
     bool succeeded = false;
 
     extraHeaders.add('Contact: $_contact');
@@ -2501,7 +2635,7 @@ class RTCSession extends EventManager implements Owner {
       sendRequest(SipMethod.ACK);
 
       // If it is a 2XX retransmission exit now.
-      if (succeeded != null) {
+      if (succeeded) {
         return;
       }
 
@@ -2711,7 +2845,8 @@ class RTCSession extends EventManager implements Owner {
 
   void _acceptAndTerminate(IncomingResponse? response,
       [int? status_code, String? reason_phrase]) async {
-    logger.d('acceptAndTerminate()');
+    logger.d(
+        'acceptAndTerminate() status_code: $status_code reason: $reason_phrase');
 
     List<dynamic> extraHeaders = <dynamic>[];
 

--- a/lib/src/sip_message.dart
+++ b/lib/src/sip_message.dart
@@ -273,10 +273,8 @@ class OutgoingRequest {
     msg += 'User-Agent: $userAgent\r\n';
 
     if (body != null) {
-      logger.d('Outgoing Message: ${body!}');
-      //Here we should calculate the real content length for UTF8
-      List<int> encoded = utf8.encode(body!);
-      int length = encoded.length;
+      logger.d('Outgoing Message: $method body: $body');
+      int length = utf8.encode(body!).length;
       msg += 'Content-Length: $length\r\n\r\n';
       msg += body!;
     } else {
@@ -628,6 +626,10 @@ class IncomingRequest extends IncomingMessage {
 
     if (body != null) {
       int length = body.length;
+      int utf8Length = utf8.encode(body).length;
+      if (length != utf8Length) {
+        logger.w('WARNING Non-ASCII character detected in message body');
+      }
 
       response += 'Content-Type: application/sdp\r\n';
       response += 'Content-Length: $length\r\n\r\n';

--- a/lib/src/socket_transport.dart
+++ b/lib/src/socket_transport.dart
@@ -135,7 +135,6 @@ class SocketTransport {
       return false;
     }
     String message = data.toString();
-    message.split('fingerprint');
     return socket.send(message);
   }
 

--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -835,6 +835,9 @@ class UA extends EventManager {
     // String containing _configuration.uri without scheme and user.
     URI hostport_params = _configuration.uri.clone();
 
+    _configuration.terminateOnAudioMediaPortZero =
+        configuration.terminateOnAudioMediaPortZero;
+
     hostport_params.user = null;
     _configuration.hostport_params = hostport_params
         .toString()
@@ -963,6 +966,8 @@ class UA extends EventManager {
 
     // Do some sanity check.
     if (!sanityCheck(message, this, transport)) {
+      logger.w(
+          'Incoming message did not pass sanity test, dumping it: \n\n $message');
       return;
     }
 


### PR DESCRIPTION
Had to make an adjustment on the first PR, then it started failing some formatter check, hopefully this one cleanly passes the checks.


Added the infrastructure to be able to upgrade a voice call to a video call. This introduced a new listener function to override 'onNewReinvite(ReInvite event)' which is used by the app that uses the package so it can handle the UI for the upgrade request. Also updated the example app to use the upgrade to video functionality.

Added darkmode to the example app.

Refactored how the call screen detects whether it is a voiceOnly call. Previously you could make a video call and the remote side would be told its an audio call. Only when they accept are they suprised to see its a video call. Now on an incoming call it detects if remote has video and for an outgoing call, whether it is video or not is added into the Call object so when you go to call screen you instantly know whether it is voiceOnly or not.

Added optional functionality to terminate the call if the mediaPort is 0. In some cases when you make an audio call and the port is 0 then if the call goes ahead you're not going to get any audio. But theres also the case where you might want to join a conference call without audio. So i made this an option in the Settings object so it can be used for the first case but not interrupt any other cases.