### PR TITLE
Hold and video upgrade fixed

### DIFF
--- a/example/lib/src/callscreen.dart
+++ b/example/lib/src/callscreen.dart
@@ -181,7 +181,10 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
       if (_localRenderer != null) {
         _localRenderer!.srcObject = stream;
       }
-      if (!kIsWeb && !WebRTC.platformIsDesktop) {
+
+      if (!kIsWeb &&
+          !WebRTC.platformIsDesktop &&
+          event.stream?.getAudioTracks().isNotEmpty == true) {
         event.stream?.getAudioTracks().first.enableSpeakerphone(false);
       }
       _localStream = stream;
@@ -334,10 +337,14 @@ class _MyCallScreenWidget extends State<CallScreenWidget>
         call!.voiceOnly = false;
       });
       helper!.renegotiate(
-          call: call!, voiceOnly: false, done: (incomingMessage) {});
+          call: call!,
+          voiceOnly: false,
+          done: (IncomingMessage? incomingMessage) {});
     } else {
       helper!.renegotiate(
-          call: call!, voiceOnly: true, done: (incomingMessage) {});
+          call: call!,
+          voiceOnly: true,
+          done: (IncomingMessage? incomingMessage) {});
     }
   }
 

--- a/example/lib/src/register.dart
+++ b/example/lib/src/register.dart
@@ -156,6 +156,27 @@ class _MyRegisterWidget extends State<RegisterWidget>
       appBar: AppBar(
         title: Text("SIP Account"),
       ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: SizedBox(
+                    height: 40,
+                    child: ElevatedButton(
+                      child: Text('Register'),
+                      onPressed: () => _handleSave(context),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
       body: ListView(
         padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 20),
         children: <Widget>[
@@ -281,11 +302,6 @@ class _MyRegisterWidget extends State<RegisterWidget>
               ],
             ),
           ],
-          const SizedBox(height: 20),
-          ElevatedButton(
-            child: Text('Register'),
-            onPressed: () => _handleSave(context),
-          ),
         ],
       ),
     );

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:dart_sip_ua_example/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -123,7 +123,7 @@ class SIPUAHelper extends EventManager {
     required bool voiceOnly,
     Map<String, dynamic>? options,
     bool useUpdate = false,
-    Function(IncomingMessage)? done,
+    Function(IncomingMessage?)? done,
   }) async {
     Map<String, dynamic> finalOptions = options ?? buildCallOptions(voiceOnly);
     call.renegotiate(options: finalOptions, useUpdate: useUpdate, done: done);
@@ -600,7 +600,7 @@ class Call {
   void renegotiate({
     required Map<String, dynamic>? options,
     bool useUpdate = false,
-    Function(IncomingMessage)? done,
+    Function(IncomingMessage?)? done,
   }) {
     assert(_session != null, 'ERROR(renegotiate): rtc session is invalid!');
     _session.renegotiate(options: options, useUpdate: useUpdate, done: done);


### PR DESCRIPTION
Where as before i was using _sendReinvite() for the video upgrade, the video upgrade logic was interfering with the hold logic. Now i have reverted _sendReinvite() back to how it was and introduced a new _sendVideoUpgrade() for a seperation of concern. 

Tested on a FreePBX server that hold is now working. Also to note a few people have said the other side doesnt get notified if they're put on hold. This actually does work with this package but their problem is a PBX problem specifically they havent set moh_passthrough = yes on their endpoints. With that configuration I observer the other side displaying that they had been put on hold by the remote.

This also fixed  #492 where event handlers were unneccesarily being introduced.
and #473 with the hold get media types error.