### PR TITLE
Concurrent modification during iteration bug fix

### DIFF
--- a/lib/src/ua.dart
+++ b/lib/src/ua.dart
@@ -317,7 +317,7 @@ class UA extends EventManager {
     int num_sessions = _sessions.length;
 
     // Run  _terminate_ on every Session.
-    _sessions.forEach((String? key, _) {
+    _sessions.keys.toList().forEach((String? key, _) {
       if (_sessions.containsKey(key)) {
         logger.d('closing session $key');
         try {


### PR DESCRIPTION
Hey there! 

Sometimes I am getting a bug like this:
```
Concurrent modification during iteration: _Map len:1.
StackTrace: #0      _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:635)
#1      UA.stop (package:sip_ua/src/ua.dart:325)
```
I was wondering what causes the bug and found that there is a case when call is stopping but package is trying to destroy session in sessions list at the same time. I saw that you have `_stopping` flag already in your `stop` function and use it to prevent list modifications if they can cause an error. So I taught that I can use that flag to fix my problem. 

Seems like I am not getting this error any more :)